### PR TITLE
Fix missing quotes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Fort('.fort').solid("#6638F0");
 * [Gradient](https://idriskhenchil.com/fort/gradient) - `gradient()`
 
 **Changing the colors:**
-* Solid - `Fort('.target').solid(#009DFF")` 
+* Solid - `Fort('.target').solid("#009DFF")` 
 
 
-* Gradient - `Fort('.target').gradient(#009DFF", "#47B9FF")` Note: Only pass two color values.
+* Gradient - `Fort('.target').gradient("#009DFF", "#47B9FF")` Note: Only pass two color values.
 
 
 ## License


### PR DESCRIPTION
Came from the orange website to check it out, and just couldn't help but notice :')